### PR TITLE
Fixing the Type Issues in src/fibRoute.ts identified by the linter

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
 import fibonacci from "./fib";
+import type { Request, Response } from "express";
 
-export default (req, res) => {
+export default (req: Request, res: Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
Request and Response types were imported from the express library so that the corresponding variables could be explicitly typed, eliminating the type any errors that the Linter identified.